### PR TITLE
Remove demo account section and update page title

### DIFF
--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -302,16 +302,6 @@ export default function Auth() {
             </form>
           )}
 
-          {/* Demo Account */}
-          <div className="mt-6 pt-6 border-t border-border/50">
-            <p className="text-xs text-foreground/60 text-center mb-3">
-              Для тестирования:
-            </p>
-            <div className="text-xs text-foreground/80 text-center space-y-1">
-              <p>Email: demo@example.com</p>
-              <p>Пароль: demo123</p>
-            </div>
-          </div>
         </Card>
 
         {/* Back to Home */}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hello world project</title>
+    <title>FaceIt evo</title>
   </head>
 
   <body>


### PR DESCRIPTION
This pull request makes two changes:

1. Removes the demo account section from the Auth page that displayed test credentials (demo@example.com / demo123)
2. Updates the HTML page title from "Hello world project" to "FaceIt evo"

The demo account section included Russian text and test login credentials that have been completely removed from the authentication form.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/1a1d00c25a014de5836c3ddac7369a99/vortex-zone)

👀 [Preview Link](https://1a1d00c25a014de5836c3ddac7369a99-vortex-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1a1d00c25a014de5836c3ddac7369a99</projectId>-->
<!--<branchName>vortex-zone</branchName>-->