### PR TITLE
Update Telegram config environment variable handling

### DIFF
--- a/server/config/telegramConfig.ts
+++ b/server/config/telegramConfig.ts
@@ -145,12 +145,10 @@ export function validateTelegramConfig(config: AppTelegramConfig): {
 export function getTelegramConfigForEnvironment(
   env: "development" | "production" | "test",
 ): Partial<AppTelegramConfig> {
-  const baseConfig = loadTelegramConfig();
-
   switch (env) {
     case "development":
       return {
-        enableNotifications: baseConfig.enableNotifications,
+        enableNotifications: process.env.TELEGRAM_NOTIFICATIONS === "true",
         limits: {
           ...defaultTelegramConfig.limits,
           commandCooldown: 500,
@@ -158,7 +156,7 @@ export function getTelegramConfigForEnvironment(
       };
     case "production":
       return {
-        enableNotifications: true,
+        enableNotifications: process.env.TELEGRAM_NOTIFICATIONS !== "false",
         limits: {
           ...defaultTelegramConfig.limits,
           commandCooldown: 2000,

--- a/server/config/telegramConfig.ts
+++ b/server/config/telegramConfig.ts
@@ -94,7 +94,10 @@ export function loadTelegramConfig(): AppTelegramConfig {
       process.env.TELEGRAM_ADMIN_CHAT_ID || defaultTelegramConfig.adminChatId,
     webhookUrl:
       process.env.TELEGRAM_WEBHOOK_URL || defaultTelegramConfig.webhookUrl,
-    enableNotifications: process.env.TELEGRAM_NOTIFICATIONS !== "false",
+    enableNotifications:
+      process.env.NODE_ENV === "production"
+        ? process.env.TELEGRAM_NOTIFICATIONS !== "false"
+        : process.env.TELEGRAM_NOTIFICATIONS === "true",
     enableAuth: process.env.TELEGRAM_AUTH !== "false",
     autoCreateUsers: process.env.TELEGRAM_AUTO_CREATE_USERS !== "false",
   };
@@ -108,10 +111,13 @@ export function validateTelegramConfig(config: AppTelegramConfig): {
   const errors: string[] = [];
 
   if (!config.token || config.token.length < 10) {
-    errors.push("Отсутствует или некорректный TELEGRAM_BOT_TOKEN");
+    errors.push("Отсутст��ует или некорректный TELEGRAM_BOT_TOKEN");
   }
 
-  if (config.enableNotifications && !config.notificationChatId) {
+  if (
+    config.enableNotifications &&
+    (!config.notificationChatId || config.notificationChatId.trim() === "")
+  ) {
     errors.push(
       "Уведомления включены, но не указан TELEGRAM_CHAT_ID или TELEGRAM_NOTIFICATION_CHAT_ID",
     );

--- a/server/config/telegramConfig.ts
+++ b/server/config/telegramConfig.ts
@@ -89,7 +89,9 @@ export function loadTelegramConfig(): AppTelegramConfig {
     // Переопределяем значения из environment variables если они есть
     token: process.env.TELEGRAM_BOT_TOKEN || defaultTelegramConfig.token,
     notificationChatId:
-      process.env.TELEGRAM_CHAT_ID || defaultTelegramConfig.notificationChatId,
+      process.env.TELEGRAM_CHAT_ID ||
+      process.env.TELEGRAM_NOTIFICATION_CHAT_ID ||
+      defaultTelegramConfig.notificationChatId,
     adminChatId:
       process.env.TELEGRAM_ADMIN_CHAT_ID || defaultTelegramConfig.adminChatId,
     webhookUrl:

--- a/server/config/telegramConfig.ts
+++ b/server/config/telegramConfig.ts
@@ -111,7 +111,7 @@ export function validateTelegramConfig(config: AppTelegramConfig): {
   const errors: string[] = [];
 
   if (!config.token || config.token.length < 10) {
-    errors.push("Отсутст��ует или некорректный TELEGRAM_BOT_TOKEN");
+    errors.push("Отсутствует или некорректный TELEGRAM_BOT_TOKEN");
   }
 
   if (
@@ -143,10 +143,12 @@ export function validateTelegramConfig(config: AppTelegramConfig): {
 export function getTelegramConfigForEnvironment(
   env: "development" | "production" | "test",
 ): Partial<AppTelegramConfig> {
+  const baseConfig = loadTelegramConfig();
+
   switch (env) {
     case "development":
       return {
-        enableNotifications: false,
+        enableNotifications: baseConfig.enableNotifications,
         limits: {
           ...defaultTelegramConfig.limits,
           commandCooldown: 500,


### PR DESCRIPTION
Updates Telegram configuration to improve environment variable handling:

- Add fallback to TELEGRAM_NOTIFICATION_CHAT_ID environment variable for notificationChatId
- Change enableNotifications logic to be environment-specific:
  - Production: defaults to true unless explicitly set to "false"
  - Development: defaults to false unless explicitly set to "true"
- Update validation to check for empty/whitespace-only notificationChatId values
- Apply consistent enableNotifications logic in getTelegramConfigForEnvironment function

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/1a1d00c25a014de5836c3ddac7369a99/flare-hub)

👀 [Preview Link](https://1a1d00c25a014de5836c3ddac7369a99-flare-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1a1d00c25a014de5836c3ddac7369a99</projectId>-->
<!--<branchName>flare-hub</branchName>-->